### PR TITLE
Add client access token persistance support to Azure Key Vault.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,5 @@ ASP.NET Core helper library managing user and client access tokens in ASP.NET Co
 The token management library powering our [Duende.BFF](https://duendesoftware.com/products/bff) SPA/BlazorWASM security library. 
 
 See [here](https://identitymodel.readthedocs.io/en/latest/aspnetcore/overview.html) for documentation.
+
+See sample for Azure Key vault configuration with Azure client secret credential in the sample section under the Worker project. The configuration values for the Azure Key Vault should be provided in appsettings.json.

--- a/samples/Worker/appsettings.json
+++ b/samples/Worker/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "AzureKeyVault": {
+    "Url": "{YOUR_VAULT_URL}",
+    "TenantId": "{YOUR_TENANT_ID}",
+    "ClientId": "{YOUR_CLIENT_ID}",
+    "ClientSecret": "{YOUR_CLIENT_SECRET}"
+  }
+}

--- a/src/AccessTokenManagement/Azure/KeyVaultClientAccessTokenCache.cs
+++ b/src/AccessTokenManagement/Azure/KeyVaultClientAccessTokenCache.cs
@@ -16,6 +16,7 @@ namespace IdentityModel.AspNetCore.AccessTokenManagement.Azure
         private readonly SecretClient _secretClient;
         private readonly ILogger<KeyVaultClientAccessTokenCache> _logger;
         private readonly ClientAccessTokenManagementOptions _options;
+        private const string KeySeparator = "--";
 
         /// <summary>
         /// ctor
@@ -40,7 +41,7 @@ namespace IdentityModel.AspNetCore.AccessTokenManagement.Azure
             CancellationToken cancellationToken = default)
         {
             var cacheKey = GenerateCacheKey(clientName, parameters);
-            Response<KeyVaultSecret>? response = null;
+            Response<KeyVaultSecret>? response;
 
             try
             {
@@ -49,6 +50,7 @@ namespace IdentityModel.AspNetCore.AccessTokenManagement.Azure
             catch (RequestFailedException e) when (e.Status == StatusCodes.Status404NotFound) 
             {
                 _logger.LogDebug("Cache miss for access token for client: {clientName}", clientName);
+                return null;
             }
 
             if (response!.Value.Properties.ExpiresOn.GetValueOrDefault() <= DateTimeOffset.UtcNow)
@@ -106,6 +108,6 @@ namespace IdentityModel.AspNetCore.AccessTokenManagement.Azure
         private string GenerateCacheKey(
             string clientName,
             ClientAccessTokenParameters? parameters = null) =>
-                "IdentityModel--AccessTokenManagement" + "--" + clientName + "--" + parameters?.Resource ?? "";
+                $"{nameof(IdentityModel)}{KeySeparator}{nameof(AccessTokenManagement)}{KeySeparator}{clientName}{KeySeparator}{parameters?.Resource ?? string.Empty}";
     }
 }

--- a/src/AccessTokenManagement/Azure/KeyVaultClientAccessTokenCache.cs
+++ b/src/AccessTokenManagement/Azure/KeyVaultClientAccessTokenCache.cs
@@ -1,0 +1,119 @@
+﻿using Azure;
+using Azure.Identity;
+using Azure.Security.KeyVault.Secrets;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace IdentityModel.AspNetCore.AccessTokenManagement.Azure
+{
+    /// <summary>
+    ///     Client access token cache using Azure Key Vault SecretClient.
+    /// </summary>
+    public class KeyVaultClientAccessTokenCache : IClientAccessTokenCache
+    {
+        private readonly SecretClient _secretClient;
+        private readonly ILogger<KeyVaultClientAccessTokenCache> _logger;
+        private readonly ClientAccessTokenManagementOptions _options;
+        private const string EntrySeparator = "___";
+
+        /// <summary>
+        /// ctor
+        /// </summary>
+        /// <param name="logger"></param>
+        /// <param name="secretClient"></param>
+        /// <param name="options"></param>
+        public KeyVaultClientAccessTokenCache(
+            ILogger<KeyVaultClientAccessTokenCache> logger,
+            SecretClient secretClient,
+            ClientAccessTokenManagementOptions options)
+        {
+            _secretClient = secretClient;
+            _options = options;
+            _logger = logger;
+        }
+
+        /// <inheritdoc/>
+        public async Task<ClientAccessToken?> GetAsync(
+            string clientName, 
+            ClientAccessTokenParameters parameters,
+            CancellationToken cancellationToken = default)
+        {
+            var cacheKey = GenerateCacheKey(clientName, parameters);
+            Response<KeyVaultSecret>? response = null;
+
+            try
+            {
+                response = await _secretClient.GetSecretAsync(cacheKey, cancellationToken: cancellationToken);
+            }
+            catch (RequestFailedException e) when (e.Status == StatusCodes.Status404NotFound) { };          
+      
+            if (response is not null 
+                && response.Value is not null 
+                && !string.IsNullOrEmpty(response.Value.Value))
+            {
+                try
+                {
+                    _logger.LogDebug("Cache hit for access token for client: {clientName}", clientName);
+                    var entry = response.Value.Value;
+
+                    var index = entry.LastIndexOf(EntrySeparator, StringComparison.Ordinal);
+
+                    return new ClientAccessToken
+                    {
+                        AccessToken = entry.Substring(0, index),
+                        Expiration = DateTimeOffset.FromUnixTimeSeconds(long.Parse(entry.AsSpan(index + EntrySeparator.Length)))
+                    };
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogCritical(ex, "Error parsing cached access token for client {clientName}", clientName);
+                    return null;
+                }
+            }
+
+            _logger.LogDebug("Cache miss for access token for client: {clientName}", clientName);
+            return null;
+        }
+
+        /// <inheritdoc/>
+        public async Task DeleteAsync(string clientName, ClientAccessTokenParameters parameters, CancellationToken cancellationToken = default)
+        {
+            if (clientName is null) throw new ArgumentNullException(nameof(clientName));
+
+            var cacheKey = GenerateCacheKey(clientName, parameters);
+
+            var operation = await _secretClient.StartDeleteSecretAsync(cacheKey, cancellationToken);
+            await operation.WaitForCompletionAsync(cancellationToken);
+            await _secretClient.PurgeDeletedSecretAsync(cacheKey, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public async Task SetAsync(string clientName, string accessToken, int expiresIn, ClientAccessTokenParameters parameters, CancellationToken cancellationToken = default)
+        {
+
+            if (clientName is null) throw new ArgumentNullException(nameof(clientName));
+
+            var expiration = DateTimeOffset.UtcNow.AddSeconds(expiresIn);
+            var expirationEpoch = expiration.ToUnixTimeSeconds();
+            var cacheExpiration = expiration.AddSeconds(-_options.CacheLifetimeBuffer);
+
+            var data = $"{accessToken}{EntrySeparator}{expirationEpoch}";          
+
+            _logger.LogDebug("Caching access token for client: {clientName}. Expiration: {expiration}", clientName, cacheExpiration);
+
+            var cacheKey = GenerateCacheKey(clientName, parameters);
+
+            var kvSecret = new KeyVaultSecret(cacheKey, data);
+            kvSecret.Properties.ExpiresOn = expiration;
+            await _secretClient.SetSecretAsync(kvSecret, cancellationToken);
+        }
+
+        private string GenerateCacheKey(
+            string clientName,
+            ClientAccessTokenParameters? parameters = null) =>
+                "IdentityModel--AccessTokenManagement" + "--" + clientName + "--" + parameters?.Resource ?? "";
+    }
+}

--- a/src/AccessTokenManagement/Azure/KeyVaultClientAccessTokenCache.cs
+++ b/src/AccessTokenManagement/Azure/KeyVaultClientAccessTokenCache.cs
@@ -1,0 +1,119 @@
+﻿using Azure;
+using Azure.Identity;
+using Azure.Security.KeyVault.Secrets;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace IdentityModel.AspNetCore.AccessTokenManagement.Azure
+{
+    /// <summary>
+    ///     Client access token cache using Azure Key Vault SecretClient.
+    /// </summary>
+    public class KeyVaultClientAccessTokenCache : IClientAccessTokenCache
+    {
+        private readonly SecretClient _secretClient;
+        private readonly ILogger<KeyVaultClientAccessTokenCache> _logger;
+        private readonly ClientAccessTokenManagementOptions _options;
+        private const string EntrySeparator = "___";
+
+        /// <summary>
+        /// ctor
+        /// </summary>
+        /// <param name="logger"></param>
+        /// <param name="secretClient"></param>
+        /// <param name="options"></param>
+        public KeyVaultClientAccessTokenCache(
+            ILogger<KeyVaultClientAccessTokenCache> logger,
+            SecretClient secretClient,
+            ClientAccessTokenManagementOptions options)
+        {
+            _secretClient = secretClient;
+            _options = options;
+            _logger = logger;
+        }
+
+        /// <inheritdoc/>
+        public async Task<ClientAccessToken?> GetAsync(
+            string clientName, 
+            ClientAccessTokenParameters parameters,
+            CancellationToken cancellationToken = default)
+        {
+            var cacheKey = GenerateCacheKey(clientName, parameters);
+            Response<KeyVaultSecret>? response = null;
+
+            try
+            {
+                response = await _secretClient.GetSecretAsync(cacheKey, cancellationToken: cancellationToken);
+            }
+            catch (RequestFailedException e) when (e.Status == StatusCodes.Status404NotFound) { };          
+      
+            if (response is not null 
+                && response.Value is not null 
+                && !string.IsNullOrEmpty(response.Value.Value))
+            {
+                try
+                {
+                    _logger.LogDebug("Cache hit for access token for client: {clientName}", clientName);
+                    var entry = response.Value.Value;
+
+                    var index = entry.LastIndexOf(EntrySeparator, StringComparison.Ordinal);
+
+                    return new ClientAccessToken
+                    {
+                        AccessToken = entry.Substring(0, index),
+                        Expiration = DateTimeOffset.FromUnixTimeSeconds(long.Parse(entry.AsSpan(index + EntrySeparator.Length)))
+                    };
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogCritical(ex, "Error parsing cached access token for client {clientName}", clientName);
+                    return null;
+                }
+            }
+
+            _logger.LogDebug("Cache miss for access token for client: {clientName}", clientName);
+            return null;
+        }
+
+        /// <inheritdoc/>
+        public async Task DeleteAsync(string clientName, ClientAccessTokenParameters parameters, CancellationToken cancellationToken = default)
+        {
+            if (clientName is null) throw new ArgumentNullException(nameof(clientName));
+
+            var cacheKey = GenerateCacheKey(clientName, parameters);
+
+            var operation = await _secretClient.StartDeleteSecretAsync(cacheKey, cancellationToken);
+            await operation.WaitForCompletionAsync(cancellationToken);
+            await _secretClient.PurgeDeletedSecretAsync(cacheKey, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public async Task SetAsync(string clientName, string accessToken, int expiresIn, ClientAccessTokenParameters parameters, CancellationToken cancellationToken = default)
+        {
+
+            if (clientName is null) throw new ArgumentNullException(nameof(clientName));
+
+            var expiration = DateTimeOffset.UtcNow.AddSeconds(expiresIn);
+            var expirationEpoch = expiration.ToUnixTimeSeconds();
+            var cacheExpiration = expiration.AddSeconds(-_options.CacheLifetimeBuffer);
+
+            var data = $"{accessToken}{EntrySeparator}{expirationEpoch}";          
+
+            _logger.LogDebug("Caching access token for client: {clientName}. Expiration: {expiration}", clientName, cacheExpiration);
+
+            var cacheKey = GenerateCacheKey(clientName, parameters);
+
+            var kvSecret = new KeyVaultSecret(cacheKey, data);
+            kvSecret.Properties.ExpiresOn = expiration;
+            await _secretClient.SetSecretAsync(cacheKey, data, cancellationToken);
+        }
+
+        private string GenerateCacheKey(
+            string clientName,
+            ClientAccessTokenParameters? parameters = null) =>
+                "IdentityModel--AccessTokenManagement" + "--" + clientName + "--" + parameters?.Resource ?? "";
+    }
+}

--- a/src/AccessTokenManagement/Azure/KeyVaultOptions.cs
+++ b/src/AccessTokenManagement/Azure/KeyVaultOptions.cs
@@ -3,10 +3,19 @@ using System;
 
 namespace IdentityModel.AspNetCore.AccessTokenManagement.Azure
 {
+    /// <summary>
+    ///     Azure Key Vault options
+    /// </summary>
     public class KeyVaultOptions
     {
-        public Uri Url { get; set; }
+        /// <summary>
+        ///  Azure Key Vault Url
+        /// </summary>
+        public Uri? Url { get; set; }
 
-        public TokenCredential Credential { get; set; }
+        /// <summary>
+        ///  Azure Key credentials(client, certificate, default, etc.)
+        /// </summary>
+        public TokenCredential? Credential { get; set; }
     }
 }

--- a/src/AccessTokenManagement/Azure/KeyVaultOptions.cs
+++ b/src/AccessTokenManagement/Azure/KeyVaultOptions.cs
@@ -14,7 +14,7 @@ namespace IdentityModel.AspNetCore.AccessTokenManagement.Azure
         public Uri? Url { get; set; }
 
         /// <summary>
-        ///  Azure Key credentials(client, certificate, default, etc.)
+        ///  Azure Key Vault credentials(client, certificate, default, etc.)
         /// </summary>
         public TokenCredential? Credential { get; set; }
     }

--- a/src/AccessTokenManagement/Azure/KeyVaultOptions.cs
+++ b/src/AccessTokenManagement/Azure/KeyVaultOptions.cs
@@ -1,0 +1,12 @@
+﻿using Azure.Core;
+using System;
+
+namespace IdentityModel.AspNetCore.AccessTokenManagement.Azure
+{
+    public class KeyVaultOptions
+    {
+        public Uri Url { get; set; }
+
+        public TokenCredential Credential { get; set; }
+    }
+}

--- a/src/AccessTokenManagement/Azure/KeyVaultTokenManagementBuilderExtensions.cs
+++ b/src/AccessTokenManagement/Azure/KeyVaultTokenManagementBuilderExtensions.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+
+namespace IdentityModel.AspNetCore.AccessTokenManagement.Azure;
+
+/// <summary>
+///     Extension methods for TokenManagementBuilder to register Azure Key vault caching services.
+/// </summary>
+public static class KeyVaultTokenManagementBuilderExtensions
+{
+    /// <summary>
+    ///     Adds secret persistance to Azure Key Vault.
+    /// </summary>
+    /// <param name="tokenManagementBuilder"></param>
+    /// <param name="options"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    public static TokenManagementBuilder WithAzureKeyVault(
+        this TokenManagementBuilder tokenManagementBuilder,
+        Action<KeyVaultOptions> options)
+    {
+        if (options is null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        var keyVaultOptions = new KeyVaultOptions();
+        options(keyVaultOptions);
+
+        if (keyVaultOptions.Url is null || keyVaultOptions.Credential is null)
+        {
+            throw new ArgumentException($"Invalid or missing {nameof(keyVaultOptions.Url)} or {keyVaultOptions.Credential}.");
+        }
+
+        tokenManagementBuilder
+            .Services
+            .AddTransient<IClientAccessTokenCache, KeyVaultClientAccessTokenCache>();
+
+        tokenManagementBuilder
+            .Services.AddAzureClients(builder =>
+            {
+                builder
+                  .AddSecretClient(keyVaultOptions.Url)
+                  .WithCredential(keyVaultOptions.Credential);
+            });
+
+        return tokenManagementBuilder;
+    }
+}

--- a/src/IdentityModel.AspNetCore.csproj
+++ b/src/IdentityModel.AspNetCore.csproj
@@ -23,8 +23,12 @@
   
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Azure.Identity" Version="1.5.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.2.0" />
     
     <PackageReference Include="IdentityModel" Version="6.0.0" />
+    
+    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.1.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="minver" Version="3.0.0" PrivateAssets="All" />
   </ItemGroup>

--- a/test/Tests/Azure/KeyVaultExtensionsTests.cs
+++ b/test/Tests/Azure/KeyVaultExtensionsTests.cs
@@ -1,0 +1,41 @@
+﻿using Azure.Identity;
+using Azure.Security.KeyVault.Secrets;
+using IdentityModel.AspNetCore.AccessTokenManagement;
+using IdentityModel.AspNetCore.AccessTokenManagement.Azure;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using Xunit;
+
+namespace Tests.Azure
+{
+    public class KeyVaultExtensionsTests
+    {
+        [Fact]
+        public void WithAzureKeyVault_Register_ShouldAddExpectedServices()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            //Act
+            services
+                .AddClientAccessTokenManagement()
+                .WithAzureKeyVault(opts =>
+                {
+                    opts.Credential = new DefaultAzureCredential();
+                    opts.Url = new Uri("http://demo.com");
+                });
+
+
+            var secretClient = services.BuildServiceProvider()
+                .GetRequiredService<SecretClient>();
+
+            var clientAccessCache = services.BuildServiceProvider()
+                .GetRequiredService<IClientAccessTokenCache>();
+
+            // Assert
+            Assert.NotNull(secretClient);
+            Assert.NotNull(clientAccessCache);
+            Assert.IsType<KeyVaultClientAccessTokenCache>(clientAccessCache);
+        }
+    }
+}


### PR DESCRIPTION
- Add WithAzureKeyVault extension for providing configurational data.
- Add AccessTokenCache implementation that stores the access token data to the Key Vault.
- Add service collection registration test.
- Add new information in the README.
- Add expiration for access tokens in key vault.